### PR TITLE
Changed code to clean up empty output file if the apollo converter ap…

### DIFF
--- a/bin/generate_gff_from_chado.py
+++ b/bin/generate_gff_from_chado.py
@@ -656,8 +656,10 @@ class ChadoGffExporter:
 					tf.write(self.construct_apollo_converter_app_cmds(inputfile, outputfile) + "\n")
 					
 					if self.copytoftpsiteflag == True:
-						tf.write("cp " + outputfile + " " + self.ftptargetfolder + "/" + "\n")
-				
+						tf.write("if [[ -s \"" + outputfile + "\" ]]; then\n")
+						tf.write("   cp " + outputfile + " " + self.ftptargetfolder + "/" + "\n")
+						tf.write("fi\n")
+
 				tf.write("\n")
 			
 			donefile = self.statuspath + "/" + scriptname + ".done"
@@ -787,6 +789,7 @@ class ChadoGffExporter:
 		cmd = cmd + "	status=$?\n"
 		cmd = cmd + "	if [[ $status -ne 0 ]]; then\n"
 		cmd = cmd + "		echo \"ERROR: " + self.apolloconverterapp + " processing failed with status $status.\" 1>&2\n"
+		cmd = cmd + "		rm -f " + outputfile + "\n"
 		cmd = cmd + "		JOB_ERROR_STATUS=1\n"
 		cmd = cmd + "	fi\n"
 		cmd = cmd + "else\n"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='chado-export',
-    version='1.1.1',
+    version='1.1.2',
     description='generate_gff_from_chado.py: a script to export organism genome data in Chado, to GFF files.',
     package_dir={'': 'bin'},
 	package_data={'chado-export': ['bin/*.ini']},


### PR DESCRIPTION
For a Chado export for Apollo, if the gff munger application returned an error, a gzipped empty file was produced. This is now removed.